### PR TITLE
Remove trailing comma

### DIFF
--- a/doc_source/pstools-discovery-aliases.rst
+++ b/doc_source/pstools-discovery-aliases.rst
@@ -184,7 +184,7 @@ to the supported AWS services.
     "SQS",  # Amazon Simple Queue Service
     "SSM",  # Amazon Simple Systems Management
     "STS",  # AWS Security Token Service
-    "WKS",  # Amazon WorkSpaces
+    "WKS"   # Amazon WorkSpaces
     
     foreach ($s in $services)
     {


### PR DESCRIPTION
Comma on like 187, after "WKS" causes the variable assignment to fail, resulting in the entire code block failure.