### PR TITLE
Adding documentation for the new ZIP archive downloads.

### DIFF
--- a/doc_source/pstools-getting-set-up-linux-mac.md
+++ b/doc_source/pstools-getting-set-up-linux-mac.md
@@ -32,7 +32,10 @@ To run the AWS Tools for PowerShell Core, your computer must be running PowerShe
 
 You can install the modularized version of AWS Tools for PowerShell on computers that are running PowerShell Core 6\.0 or later\. For information about how to install PowerShell Core, see [https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell](https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell)\. 
 
-You can install AWS\.Tools manually, by using the `Install-Module` cmdlet, or by using the cmdlets in the `AWS.Tools.Installer` module\. The `AWS.Tools.Installer` module simplifies the installation and update of other AWS\.Tools modules\. `AWS.Tools.Installer` requires, and automatically downloads and installs, an updated version of `PowerShellGet`\. The `AWS.Tools.Installer` module also automatically keeps your module versions in sync\. When you install or update to a newer version of one module, the cmdlets in the `AWS.Tools.Installer` automatically update all of your other AWS\.Tools modules to the same version\.
+You can install AWS\.Tools in one of three ways:
++ Using the cmdlets in the `AWS.Tools.Installer` module\. The `AWS.Tools.Installer` module simplifies the installation and update of other AWS\.Tools modules\. `AWS.Tools.Installer` requires, and automatically downloads and installs, an updated version of `PowerShellGet`\. The `AWS.Tools.Installer` module also automatically keeps your module versions in sync\. When you install or update to a newer version of one module, the cmdlets in the `AWS.Tools.Installer` automatically update all of your other AWS\.Tools modules to the same version\.
++ Installing each service module from PowerShell Gallery using the `Install-Module` cmdlet\.
++ Downloading the modules as a [ZIP archive](https://sdk-for-net.amazonwebservices.com/ps/v4/latest/AWS.Tools.zip) and extracting them in one of the module directories\. You can discover your module directories by printing the value of the `$Env:PSModulePath` variable.
 
 **To install AWS\.Tools on Linux or macOS**
 
@@ -44,7 +47,7 @@ You can install AWS\.Tools manually, by using the `Install-Module` cmdlet, or by
 **Note**  
 We recommend that you *don't* run PowerShell as an administrator with elevated permissions except when required by the task at hand\. This is because of the potential security risk and is inconsistent with the principle of least privilege\.
 
-1. To install the modularized AWS\.Tools package, run the following command\.
+1. To install the modularized AWS\.Tools package using the AWS\.Tools\.Installer module, run the following command\.
 
    ```
    PS > Install-Module -Name AWS.Tools.Installer
@@ -93,6 +96,10 @@ The `Install-AWSToolsModule` cmdlet downloads all requested modules from the `PS
 
 ## Install AWSPowerShell\.NetCore on Linux or macOS<a name="install-netcore-on-linux-macos"></a>
 
+You can install AWSPowerShell\.NetCore in one of two ways:
++ Installing from PowerShell Gallery using the `Install-Module` cmdlet\.
++ Downloading the module as a [ZIP archive](https://sdk-for-net.amazonwebservices.com/ps/v4/latest/AWSPowerShell.NetCore.zip) and extracting it in one of the module directories\. You can discover your module directories by printing the value of the `$Env:PSModulePath` variable.
+
 To upgrade to a newer release of AWSPowerShell\.NetCore, follow the instructions in [Updating the AWS Tools for PowerShell on Linux or macOS](#pstools-updating-linux)\. Uninstall earlier versions of AWSPowerShell\.NetCore first\.
 
 Start a PowerShell Core session by running the following command\.
@@ -104,7 +111,7 @@ $ pwsh
 **Note**  
 We recommend that you *don't* start PowerShell by running `sudo pwsh` to run PowerShell with elevated, administrator rights\. This is because of the potential security risk and is inconsistent with the principle of least privilege\.
 
-To install the AWSPowerShell\.NetCore single\-module package, run the following command\.
+To install the AWSPowerShell\.NetCore single\-module package from PowerShell Gallery, run the following command\.
 
 ```
 PS > Install-Module -Name AWSPowerShell.NetCore

--- a/doc_source/pstools-getting-set-up-windows.md
+++ b/doc_source/pstools-getting-set-up-windows.md
@@ -28,7 +28,10 @@ Newer versions of PowerShell, including PowerShell Core, are available as downlo
 
 You can install the modularized version of AWS Tools for PowerShell on computers that are running Windows with Windows PowerShell 5\.1, or PowerShell Core 6\.0 or later\. For information about how to install PowerShell Core, see [Installing various versions of PowerShell](https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell) on Microsoft's Web site\.
 
-You can install AWS\.Tools manually, by using the `Install-Module` cmdlet, or by using the cmdlets in the `AWS.Tools.Installer` module\. The `AWS.Tools.Installer` module simplifies the installation and update of other AWS\.Tools modules\. `AWS.Tools.Installer` requires, and automatically downloads and installs an updated version of `PowerShellGet`\. The `AWS.Tools.Installer` module also automatically keeps your module versions in sync\. When you install or update to a newer version of one module, the cmdlets in the `AWS.Tools.Installer` automatically update all of your other AWS\.Tools modules to the same version\.
+You can install AWS\.Tools in one of three ways:
++ Using the cmdlets in the `AWS.Tools.Installer` module\. The `AWS.Tools.Installer` module simplifies the installation and update of other AWS\.Tools modules\. `AWS.Tools.Installer` requires, and automatically downloads and installs, an updated version of `PowerShellGet`\. The `AWS.Tools.Installer` module also automatically keeps your module versions in sync\. When you install or update to a newer version of one module, the cmdlets in the `AWS.Tools.Installer` automatically update all of your other AWS\.Tools modules to the same version\.
++ Installing each service module from PowerShell Gallery using the `Install-Module` cmdlet\.
++ Downloading the modules as a [ZIP archive](https://sdk-for-net.amazonwebservices.com/ps/v4/latest/AWS.Tools.zip) and extracting them in one of the module folders\. You can discover your module folders by printing the value of the `$Env:PSModulePath` variable.
 
 **To install AWS\.Tools on Windows**
 
@@ -87,7 +90,11 @@ The `Install-AWSToolsModule` cmdlet downloads all requested modules from the `PS
 
 You can install the AWSPowerShell\.NetCore on computers that are running Windows with PowerShell version 3 through 5\.1, or PowerShell Core 6\.0 or later\. For information about how to install PowerShell Core, see [https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell](https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell)\.
 
-To install the AWS Tools for PowerShell Core, your computer must be running PowerShell 5\.0 or later, or running [PowerShellGet](https://www.powershellgallery.com/packages/PowerShellGet) on PowerShell 3 or later\. Run the following command\.
+You can install AWSPowerShell\.NetCore in one of two ways:
++ Installing from PowerShell Gallery using the `Install-Module` cmdlet\.
++ Downloading the module as a [ZIP archive](https://sdk-for-net.amazonwebservices.com/ps/v4/latest/AWSPowerShell.NetCore.zip) and extracting it in one of the module directories\. You can discover your module directories by printing the value of the `$Env:PSModulePath` variable.
+
+To install the AWSPowerShell\.NetCore from the PowerShell Gallery, your computer must be running PowerShell 5\.0 or later, or running [PowerShellGet](https://www.powershellgallery.com/packages/PowerShellGet) on PowerShell 3 or later\. Run the following command\.
 
 ```
 PS > Install-Module -name AWSPowerShell.NetCore
@@ -111,18 +118,16 @@ To load the AWSPowerShell\.NetCore module into a PowerShell session automaticall
 
 ## Install AWSPowerShell on Windows PowerShell<a name="ps-installing-awswindowspowershell"></a>
 
-You can install the AWS Tools for Windows PowerShell in one of two ways, depending on which version of Windows PowerShell you have installed:
-+ If you're running PowerShell 5\.0 or later, or have installed [PowerShellGet](https://www.powershellgallery.com/packages/PowerShellGet) on PowerShell 3 or later, you can install and update AWSPowerShell from Microsoft's [PowerShell Gallery](https://www.powershellgallery.com/packages/AWSPowerShell) by running the following command\.
+You can install AWSPowerShell in one of three ways:
++ Installing from PowerShell Gallery using the `Install-Module` cmdlet\.
++ Downloading the module as a [ZIP archive](https://sdk-for-net.amazonwebservices.com/ps/v4/latest/AWSPowerShell.zip) and extracting it in one of the module directories\. You can discover your module directories by printing the value of the `$Env:PSModulePath` variable.
++ Running the [Tools for Windows PowerShell installer](https://sdk-for-net.amazonwebservices.com/latest/AWSToolsAndSDKForNet.msi). This method of installing AWSPowerShell is deprecated and we recommend that you use `Install-Module` instead.
+
+You can install the AWSPowerShell from the PowerShell Gallery if you're running PowerShell 5\.0 or later, or have installed [PowerShellGet](https://www.powershellgallery.com/packages/PowerShellGet) on PowerShell 3 or later\. You can install and update AWSPowerShell from Microsoft's [PowerShell Gallery](https://www.powershellgallery.com/packages/AWSPowerShell) by running the following command\.
 
   ```
   PS > Install-Module -Name AWSPowerShell
   ```
-+ If you're running a version of PowerShell earlier than 5\.0, you can run the Tools for Windows PowerShell installer `.msi`\. To download the installer, navigate to [http://aws.amazon.com/powershell/](http://aws.amazon.com/powershell/), and then choose **AWS Tools for Windows Installer**\.
-**Note**  
-You can run the installer `.msi` if you're running Windows PowerShell 5\.0 or later\. But we recommend that you use the Install\-Module cmdlet instead so that you have easier support for updating or removing the module\.
-
-  The installer includes the most recent versions of the AWS SDK for \.NET assemblies for the \.NET 3\.5 and 4\.5 Frameworks\. If you have Visual Studio 2013 or 2015 or later installed, the installer can also install the [AWS Toolkit for Visual Studio](https://docs.aws.amazon.com/toolkit-for-visual-studio/latest/user-guide/welcome.html)\.
-
 To load the AWSPowerShell module into a PowerShell session automatically, add the previous `import-module` cmdlet to your PowerShell profile\. For more information about editing your PowerShell profile, see [About Profiles](https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_profiles?view=powershell-6) in the PowerShell documentation\.
 
 **Note**  

--- a/doc_source/pstools-welcome.md
+++ b/doc_source/pstools-welcome.md
@@ -20,6 +20,8 @@ The AWS Tools for PowerShell are available as the following three distinct packa
 
 [ ![\[Image NOT FOUND\]](http://docs.aws.amazon.com/powershell/latest/userguide/images/PowerShell%20Gallery-AWS.Tools-blue.png) ](https://www.powershellgallery.com/packages/AWS.Tools.Common)
 
+[ ![\[Image NOT FOUND\]](http://docs.aws.amazon.com/powershell/latest/userguide/images/ZIP%20Archive-AWS.Tools-yellow.png) ](https://sdk-for-net.amazonwebservices.com/ps/v4/latest/AWS.Tools.zip)
+
 This version of AWS Tools for PowerShell is the recommended version for any computer running PowerShell in a production environment\. Because it's modularized, you need to download and load only the modules for the services you want to use\. This reduces download times, memory usage, and enables auto\-importing of AWS\.Tools cmdlets with the need to manually call `Import-Module` first\.
 
 This is the latest version of AWS Tools for PowerShell and runs on all supported operating systems, including Windows, Linux, and macOS\. This package provides one installation module, `AWS.Tools.Installer`, one common module, `AWS.Tools.Common`, and one module for each AWS service, for example, `AWS.Tools.EC2`, `AWS.Tools.IAM`, `AWS.Tools.S3`, and so on\.
@@ -38,6 +40,8 @@ Throughout this guide, when we need to specify this version only, we refer to it
 
 [ ![\[Image NOT FOUND\]](http://docs.aws.amazon.com/powershell/latest/userguide/images/PowerShell-Gallery-AWSPowerShell.NetCore-blue.png) ](https://www.powershellgallery.com/packages/AWSPowerShell.NetCore/)
 
+[ ![\[Image NOT FOUND\]](http://docs.aws.amazon.com/powershell/latest/userguide/images/ZIP%20Archive-AWSPowerShell.NetCore-yellow.png) ](https://sdk-for-net.amazonwebservices.com/ps/v4/latest/AWSPowerShell.NetCore.zip)
+
 This version consists of a single, large module that contains support for all AWS services\. Before you can use this module, you must manually import it\.
 
 You can install this version of AWS Tools for PowerShell on computers that are running:
@@ -49,6 +53,8 @@ Throughout this guide, when we need to specify this version only, we refer to it
 ## AWSPowerShell \- A Single\-Module Version for Windows PowerShell<a name="pwsh_structure_psoldwin"></a>
 
 [ ![\[Image NOT FOUND\]](http://docs.aws.amazon.com/powershell/latest/userguide/images/PowerShell-Gallery-AWSPowerShell-blue.png) ](https://www.powershellgallery.com/packages/AWSPowerShell/)
+
+[ ![\[Image NOT FOUND\]](http://docs.aws.amazon.com/powershell/latest/userguide/images/ZIP%20Archive-AWSPowerShell-yellow.png) ](https://sdk-for-net.amazonwebservices.com/ps/v4/latest/AWSPowerShell.zip)
 
 This version of AWS Tools for PowerShell is compatible with and installable on only Windows computers that are running Windows PowerShell versions 2\.0 through 5\.1\. It is not compatible with PowerShell Core 6\.0 or later, or any other operating system \(Linux or macOS\)\. This version consists of a single, large module that contains support for all AWS services\.
 


### PR DESCRIPTION
*Description of changes:*
Adding documentation for the new ZIP archive downloads.
Also making more explicit that the MSI installer is deprecated.

In the `pstools-welcome.md` file I reference three new images:
![AWS.Tools](https://raster.shields.io/badge/ZIP%20Archive-AWS.Tools-yellow.png)
![AWSPowerShell.NetCore](https://raster.shields.io/badge/ZIP%20Archive-AWSPowerShell.NetCore-yellow.png)
![AWSPowerShell](https://raster.shields.io/badge/ZIP%20Archive-AWSPowerShell-yellow.png)
These should be added to the `http://docs.aws.amazon.com/powershell/latest/userguide/images/` directory.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
