### PR TITLE
Update saml-pst.md

### DIFF
--- a/doc_source/saml-pst.md
+++ b/doc_source/saml-pst.md
@@ -102,8 +102,11 @@ PS > Import-Module "C:\Program Files (x86)\AWS Tools\PowerShell\AWSPowerShell\AW
    Alternatively, you can specify a role without the prompt, by entering the `RoleARN`, `PrincipalARN`, and optional `NetworkCredential` parameters\. If the specified role is not listed in the assertion returned by authentication, the user is prompted to choose from available roles\.
 
    ```
-   PS > $params = @{ "NetworkCredential"=$credential, "PrincipalARN"="{arn:aws:iam::012345678912:saml-provider/ADFS}", "RoleARN"="{arn:aws:iam::012345678912:role/ADFS-Dev}"
-   }
+   PS > $params = @{
+            NetworkCredential = $credential
+            PrincipalARN      = 'arn:aws:iam::012345678912:saml-provider/ADFS'
+            RoleARN           = 'arn:aws:iam::012345678912:role/ADFS-Dev'
+        }
    PS > $epName | Set-AWSSamlRoleProfile @params -StoreAs SAMLDemoProfile1 -Verbose
    ```
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Update the 'Configuring Federated Identity with the AWS Tools for PowerShell' page to fix the example params for `Set-AWSSamlRoleProfile` when specifying `PrincipalArn` and `RoleArn` parameters to remove the incorrect curly braces and reformat the example to view nicer on the page.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
